### PR TITLE
Delete recording

### DIFF
--- a/src/pages/InstructorRecordings/InstructorRecordings.jsx
+++ b/src/pages/InstructorRecordings/InstructorRecordings.jsx
@@ -52,7 +52,7 @@ const InstructorRecordings = () => {
 				Authorization: `Token ${token.current}`,
 			}
 			})
-			.then(res => res.status === 200 ? toast.success('Quiz successfully deleted!', {icon: '🗑️',}) : toast.error('Could not delete quiz.', {}))
+			.then(res => res.status === 200 ? toast.success('Recording successfully deleted!', {icon: '🗑️',}) : toast.error('Could not delete recording.', {}))
 			.then(() => fetchRecordings())
 			.catch(error => console.error(error));
 		setOpenDialogue(false);


### PR DESCRIPTION
**Summary:**
Added a feature to enable instructors to delete recordings. A modal pops up with a confirmation prompt when the user attempts to delete a recording and a toast is displayed upon successful deletion.

**Changes:**
1. Added a delete button to the table cells containing recordings.
2. Implemented the handleDeleteRecording function which makes the call to the backend to delete the recording. A success toast message is displayed if the operation is successful and an error toast is displayed if the operation fails.
3. Created a confirmation modal that and all associated functions for displaying the modal and receiving a confirmation from the user.
4. Moved the fetchRecordings function outside of the scope of useEffect and modified the function to use promises rather than a try catch block. 
7. Defined token using useRef to avoid additional calls to the local storage API on rerenders.

**Example:**

https://github.com/user-attachments/assets/405b338a-343a-4e1b-a408-dbf916ebbbbc

