### PR TITLE
Added the create quiz button to recordings

### DIFF
--- a/src/pages/InstructorRecordings/InstructorRecordings.jsx
+++ b/src/pages/InstructorRecordings/InstructorRecordings.jsx
@@ -61,7 +61,7 @@ const InstructorRecordings = () => {
 	const handleCreateQuiz = (recordingId) => {
 		toast.promise(
 			axios.post(
-				"https://p4vum8whi1.execute-api.us-west-2.amazonaws.com/Prod/create_quiz_from_transcript", 
+				"https://jtsw0t0x32.execute-api.us-west-2.amazonaws.com/Prod/create_quiz_from_transcript", 
 				JSON.stringify({"recording_id": recordingId}),
 				{
 				headers: {


### PR DESCRIPTION
**Summary:**
Added functionality to create a quiz using the recording/transcript.

**Changes:**
1. Added the "handleCreateQuiz" function which invokes the Lambda function for creating a quiz from a given transcript.
2. Used a React Toastify promise toast message to encapsulate the lambda request. The toast message displays "Creating Quiz" while the promise is pending, "Successfully created quiz!" upon success, and "Failed to create quiz!" upon an error.
3. Added an additional button to the table rows containing the text "Create Quiz" which calls the handleCreateQuiz function, passing the recording id as a parameter.
4. Added an additional "Actions" header to the recordings table to group the delete recording and create quiz butttons.

**Example:**
Will be posted in comments after deploying to the test environment.