### PR TITLE
Remove next, add waiting message on student question

### DIFF
--- a/src/pages/StudentAnswerView.jsx
+++ b/src/pages/StudentAnswerView.jsx
@@ -106,7 +106,7 @@ const StudentAnswerView = () => {
             {loading ? (
                 <Box display="flex" flexDirection={"column"} justifyContent="center" alignItems="center" height="100vh">
 					<CircularProgress />
-                    <Typography variant='h6'>Waiting for quiz to start...</Typography>
+                    <Typography variant='h6'>Waiting for instructor to start the quiz.</Typography>
                 </Box>
             ) : quizEnded ? (
                 <QuizEndView />


### PR DESCRIPTION
**Summary:**
Removed the next button on the student question view and added a waiting message.

**Changes:**
1. Removed the next button from StudentQuestion.jsx
2. Added a Typography component containing the text "Waiting for the quiz to start..." to StudentQuestion.JSX

**Example:**
Student question without next button:
![StudentQuestion](https://github.com/user-attachments/assets/b755fee9-011c-482b-891c-569fe4249b65)

Waiting screen:
![wating](https://github.com/user-attachments/assets/225afa8f-aa54-47f7-8512-186d25cd61c1)
