### PR TITLE
integrate quiz instructor view with backend answer totals

### DIFF
--- a/src/blocks/AnswersGrid.jsx
+++ b/src/blocks/AnswersGrid.jsx
@@ -15,9 +15,8 @@ const StyledCountText = styled(Typography)(({ theme }) => ({
   marginBottom: '8px', // Space below the count before the answer option
 }));
 
-const AnswersGrid = ({ liveBarChart, sendMessage, answers, responseData = {} }) => {
-  // Calculate total responses by summing values in responseData
-  const totalResponses = Object.values(responseData).reduce((sum, count) => sum + count, 0);
+const AnswersGrid = ({ liveBarChart, sendMessage, answers, responseData }) => {
+  const totalResponses = responseData.total_responses;
 
   useEffect(() => {
     const token = localStorage.getItem('token');
@@ -33,7 +32,7 @@ const AnswersGrid = ({ liveBarChart, sendMessage, answers, responseData = {} }) 
   return (
     <Grid container spacing={2} justifyContent="center" alignItems="center">
       {answers.map((answer, index) => {
-        const count = responseData[answer] || 0;
+        const count = responseData?.answers?.[answer] || 0;
         const width = totalResponses > 0 ? (count / totalResponses) * 100 : 0;
 
         return (

--- a/src/blocks/QuizComponent.jsx
+++ b/src/blocks/QuizComponent.jsx
@@ -30,13 +30,8 @@ const QuizComponent = ({
     }
   }, [question]);
 
-  // Function to calculate total responses
-  const getTotalResponses = () => {
-    return Object.values(responseData).reduce((total, count) => total + count, 0);
-  };
-
   // Calculate progress percentage
-  const totalResponses = getTotalResponses();
+  const totalResponses = responseData.total_responses || 0;
   const progressPercentage = userCount > 0 ? (totalResponses / userCount) * 100 : 0;
 
   return (
@@ -69,7 +64,7 @@ const QuizComponent = ({
       {/* Question Text */}
       <Box mt={3} textAlign="center">
         <Typography variant="h2" gutterBottom component="div">
-          {question['question_text']}
+          {question['question_text'] || 0}
         </Typography>
       </Box>
 

--- a/src/pages/InstructorQuestionView.jsx
+++ b/src/pages/InstructorQuestionView.jsx
@@ -26,14 +26,9 @@ const InstructorQuestionView = () => {
       } else if (data.type === 'quiz_ended') {
         setQuizEnded(true);
         setCurrentQuestion(null);
-      } else if (data.type === 'user_response') {
-        console.log('Response data:', data.response);
-        setResponseData((prevData) => {
-          const updatedData = { ...prevData };
-          const response = data.response;
-          updatedData[response] = (updatedData[response] || 0) + 1;
-          return updatedData;
-        });
+      } else if (data.type === 'update_answers') {
+        console.log('Response data:', data.data);
+        setResponseData(data.data);
       } else if (data.type === 'settings') {
         setSettings(data.settings);
         setUserCount(data.user_count);


### PR DESCRIPTION
**Summary:**
Integrate the front-end instructor quiz view with the new back-end calculations for student responses/answers.

**Changes:**
1. Question totals are now updated when an update_answers event is received via the websocket connection.
2. The old user_response event is unused now, making it safe to deprecate that event on the backend.

**Example:**
Quiz view UI is unchanged
![quiz-instruct](https://github.com/user-attachments/assets/448cea65-b220-427d-8ed9-720b01d75b29)

Totals are sent up by back-end and displayed in the UI
![quiz-instruct-answer](https://github.com/user-attachments/assets/a0b74c11-10f1-4363-9a93-9a8169e9b0cb)
