### PR TITLE
use duration from question instead of quiz settings

### DIFF
--- a/src/pages/InstructorQuestionView.jsx
+++ b/src/pages/InstructorQuestionView.jsx
@@ -73,7 +73,7 @@ const InstructorQuestionView = () => {
             sendMessage={sendMessage}
             quizEnded={quizEnded}
             timerEnabled={settings['timer']}
-            timerDuration={settings['timer_duration']}
+            timerDuration={currentQuestion.duration}
             resetTimer={resetTimer}
             onTimerEnd={onTimerEnd}
           />


### PR DESCRIPTION
**Summary:**
Updated the InstructorQuestionView page to use the duration associated with the question rather than the quiz settings.

**Example:**
UI is unchanged, but now uses the question duration. Can be tested in the development environment.
![using-question-duration](https://github.com/user-attachments/assets/c07e0734-c850-42c1-a346-6cffc6a8e98b)
