### PR TITLE
Add Summary Generation Feature to Customized Menus

### DIFF
--- a/src/blocks/CustomizedMenus.jsx
+++ b/src/blocks/CustomizedMenus.jsx
@@ -77,7 +77,7 @@ export default function CustomizedMenus(props) {
     event.stopPropagation();
     handleGenerateSummary(recording.id);
     handleClose(event);
-  }
+  };
 
   const handleDeleteRecording = (event) => {
     event.stopPropagation();

--- a/src/blocks/CustomizedMenus.jsx
+++ b/src/blocks/CustomizedMenus.jsx
@@ -6,6 +6,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Divider from '@mui/material/Divider';
 import DeleteIcon from '@mui/icons-material/Delete';
 import QuizIcon from '@mui/icons-material/Quiz';
+import SummarizeIcon from '@mui/icons-material/Summarize';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 
 const StyledMenu = styled((props) => (
@@ -49,7 +50,7 @@ const StyledMenu = styled((props) => (
 }));
 
 export default function CustomizedMenus(props) {
-  const { recording, handleOpenDialogue, setSelectedRecording, setOpenNewRecording } = props;
+  const { recording, handleOpenDialogue, setSelectedRecording, setOpenNewRecording, handleGenerateSummary } = props;
 
   const [anchorEl, setAnchorEl] = React.useState(null);
   const open = Boolean(anchorEl);
@@ -71,6 +72,12 @@ export default function CustomizedMenus(props) {
     setOpenNewRecording(true);
     handleClose(event);
   };
+
+  const handleSummary = (event) => {
+    event.stopPropagation();
+    handleGenerateSummary(recording.id);
+    handleClose(event);
+  }
 
   const handleDeleteRecording = (event) => {
     event.stopPropagation();
@@ -104,6 +111,10 @@ export default function CustomizedMenus(props) {
         <MenuItem onClick={handleCreateAndStartQuiz} disableRipple>
           <QuizIcon />
           Create and Start Quiz
+        </MenuItem>
+        <MenuItem onClick={handleSummary} disableRipple>
+          <SummarizeIcon />
+          Generate Summary
         </MenuItem>
         <Divider sx={{ my: 0.5 }} />
         <MenuItem onClick={handleDeleteRecording} disableRipple>

--- a/src/pages/InstructorRecordings/InstructorRecordings.jsx
+++ b/src/pages/InstructorRecordings/InstructorRecordings.jsx
@@ -120,6 +120,35 @@ const InstructorRecordings = () => {
     setOpenDialogue(false);
   };
 
+  const handleGenerateSummary = (recordingId) => {
+    toast
+      .promise(
+        axios.post(
+          'https://6y2dyfv9k1.execute-api.us-west-2.amazonaws.com/Prod/create_summary_from_transcript',
+          { recording_id: recordingId },
+          {
+            headers: {
+              Authorization: `Token ${token.current}`,
+              'Content-Type': 'application/json',
+            },
+          }
+        ),
+        {
+          pending: 'Generating summary...',
+          success: 'Summary generated successfully!',
+          error: 'Failed to generate summary.',
+          theme,
+        }
+      )
+      .then((res) => {
+        console.log('Summary generated:', res.data);
+        // Optionally, handle the response, e.g., display the summary or update state
+      })
+      .catch((error) => {
+        console.error('Error generating summary:', error);
+      });
+  };
+
   const handleCreateQuiz = () => {
     toast
       .promise(
@@ -340,6 +369,7 @@ const InstructorRecordings = () => {
                           setSelectedRecording={setSelectedRecording}
                           setOpenNewRecording={setOpenNewRecording}
                           setOpenEditTitleDialog={setOpenEditTitleDialog}
+                          handleGenerateSummary={handleGenerateSummary}
                           setNewTitle={setNewTitle}
                         />
                       </Box>


### PR DESCRIPTION
This PR implements a new feature that allows users to generate a summary for a recording directly from the customized menus. Below are the details of the changes made:

- **Enhanced `CustomizedMenus` Component**:
  - Imported a new icon, `SummarizeIcon`, to visually represent the generate summary action.
  - Added the `handleGenerateSummary` function to the component props to enable summary generation through the menu.
  - Created a new menu item labeled 'Generate Summary' which, upon clicking, triggers the summary generation for the recording.
  - Wrapped the new menu item in a click handler to stop propagation and properly close the menu.

- **Updated `InstructorRecordings` Component**:
  - Introduced the `handleGenerateSummary` function which sends a POST request to a specified API endpoint for generating summaries based on the recording ID.
  - Utilized `toast.promise` to provide user feedback during the summary generation process, displaying messages for pending, success, and error states.
  - Added proper error handling for the summary generation process to log any issues to the console.
  - Passed the `handleGenerateSummary` prop down to `CustomizedMenus` to facilitate the new functionality in the user interface.

These enhancements will streamline the user experience, allowing easy access to summary generation directly from the menu.