### PR TITLE
Enhance Recording Management with Edit Title Feature

### DIFF
--- a/src/blocks/CustomizedMenus.jsx
+++ b/src/blocks/CustomizedMenus.jsx
@@ -3,6 +3,7 @@ import { styled, alpha } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
+import EditIcon from '@mui/icons-material/Edit';
 import Divider from '@mui/material/Divider';
 import DeleteIcon from '@mui/icons-material/Delete';
 import QuizIcon from '@mui/icons-material/Quiz';
@@ -26,7 +27,8 @@ const StyledMenu = styled((props) => (
     borderRadius: 6,
     marginTop: theme.spacing(1),
     minWidth: 180,
-    color: theme.palette.mode === 'light' ? 'rgb(55, 65, 81)' : theme.palette.grey[300],
+    color:
+      theme.palette.mode === 'light' ? 'rgb(55, 65, 81)' : theme.palette.grey[300],
     boxShadow:
       'rgb(255, 255, 255) 0px 0px 0px 0px, ' +
       'rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, ' +
@@ -42,14 +44,24 @@ const StyledMenu = styled((props) => (
         marginRight: theme.spacing(1.5),
       },
       '&:active': {
-        backgroundColor: alpha(theme.palette.primary.main, theme.palette.action.selectedOpacity),
+        backgroundColor: alpha(
+          theme.palette.primary.main,
+          theme.palette.action.selectedOpacity
+        ),
       },
     },
   },
 }));
 
 export default function CustomizedMenus(props) {
-  const { recording, handleOpenDialogue, setSelectedRecording, setOpenNewRecording } = props;
+  const {
+    recording,
+    handleOpenDialogue,
+    setSelectedRecording,
+    setOpenNewRecording,
+    setOpenEditTitleDialog,
+    setNewTitle
+  } = props;
 
   const [anchorEl, setAnchorEl] = React.useState(null);
   const open = Boolean(anchorEl);
@@ -69,6 +81,13 @@ export default function CustomizedMenus(props) {
   const handleCreateAndStartQuiz = (event) => {
     event.stopPropagation();
     setOpenNewRecording(true);
+    handleClose(event);
+  };
+
+  const handleEditTitle = (event) => {
+    event.stopPropagation();
+    setOpenEditTitleDialog(true);
+    setNewTitle(recording.title);
     handleClose(event);
   };
 
@@ -106,6 +125,10 @@ export default function CustomizedMenus(props) {
           Create and Start Quiz
         </MenuItem>
         <Divider sx={{ my: 0.5 }} />
+        <MenuItem onClick={handleEditTitle} disableRipple>
+          <EditIcon />
+          Edit Title
+        </MenuItem>
         <MenuItem onClick={handleDeleteRecording} disableRipple>
           <DeleteIcon />
           Delete Recording

--- a/src/blocks/CustomizedMenus.jsx
+++ b/src/blocks/CustomizedMenus.jsx
@@ -27,8 +27,7 @@ const StyledMenu = styled((props) => (
     borderRadius: 6,
     marginTop: theme.spacing(1),
     minWidth: 180,
-    color:
-      theme.palette.mode === 'light' ? 'rgb(55, 65, 81)' : theme.palette.grey[300],
+    color: theme.palette.mode === 'light' ? 'rgb(55, 65, 81)' : theme.palette.grey[300],
     boxShadow:
       'rgb(255, 255, 255) 0px 0px 0px 0px, ' +
       'rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, ' +
@@ -44,10 +43,7 @@ const StyledMenu = styled((props) => (
         marginRight: theme.spacing(1.5),
       },
       '&:active': {
-        backgroundColor: alpha(
-          theme.palette.primary.main,
-          theme.palette.action.selectedOpacity
-        ),
+        backgroundColor: alpha(theme.palette.primary.main, theme.palette.action.selectedOpacity),
       },
     },
   },
@@ -60,7 +56,7 @@ export default function CustomizedMenus(props) {
     setSelectedRecording,
     setOpenNewRecording,
     setOpenEditTitleDialog,
-    setNewTitle
+    setNewTitle,
   } = props;
 
   const [anchorEl, setAnchorEl] = React.useState(null);

--- a/src/blocks/CustomizedMenus.jsx
+++ b/src/blocks/CustomizedMenus.jsx
@@ -58,9 +58,8 @@ export default function CustomizedMenus(props) {
     setOpenNewRecording,
     setOpenEditTitleDialog,
     setNewTitle,
-    handleGenerateSummary
+    handleGenerateSummary,
   } = props;
-
 
   const [anchorEl, setAnchorEl] = React.useState(null);
   const open = Boolean(anchorEl);
@@ -87,8 +86,8 @@ export default function CustomizedMenus(props) {
     event.stopPropagation();
     setOpenEditTitleDialog(true);
     setNewTitle(recording.title);
-  }
-  
+  };
+
   const handleSummary = (event) => {
     event.stopPropagation();
     handleGenerateSummary(recording.id);

--- a/src/pages/InstructorRecordings/InstructorRecordings.jsx
+++ b/src/pages/InstructorRecordings/InstructorRecordings.jsx
@@ -24,7 +24,7 @@ import {
   CircularProgress,
   Slider,
   Grid,
-  FormControl,
+  FormControl, TextField,
 } from '@mui/material';
 import axios from 'axios';
 import RecordButton from '../../blocks/RecordButton';
@@ -46,8 +46,8 @@ const InstructorRecordings = () => {
   const [open, setOpen] = useState(false);
   const [selectedRecording, setSelectedRecording] = useState(null);
   const [openDialogue, setOpenDialogue] = useState(false);
-  const [setOpenEditTitleDialog] = useState(false);
-  const [setNewTitle] = useState('');
+  const [openEditTitleDialog, setOpenEditTitleDialog] = useState(false);
+  const [newTitle, setNewTitle] = useState('');
   const token = useRef(localStorage.getItem('token'));
   const theme = localStorage.getItem('themeMode');
   const navigate = useNavigate();
@@ -204,6 +204,28 @@ const InstructorRecordings = () => {
     } finally {
       setLoadingQuizzes(false);
     }
+  };
+
+  const handleUpdateTitle = () => {
+    axios
+      .patch(
+        `https://api.edukona.com/instructor-recordings/${selectedRecording}/update-title`,
+        { title: newTitle },
+        {
+          headers: {
+            Authorization: `Token ${token.current}`,
+          },
+        }
+      )
+      .then((res) => {
+        toast.success('Title updated successfully!', { theme });
+        fetchRecordings();
+      })
+      .catch((error) => {
+        console.error(error);
+        toast.error('Failed to update title.', { theme });
+      });
+    setOpenEditTitleDialog(false);
   };
 
   const handleAccordionChange = (recordingId) => (event, isExpanded) => {
@@ -481,6 +503,32 @@ const InstructorRecordings = () => {
             </Button>
           </DialogActions>
         </Dialog>
+        <Dialog
+        open={openEditTitleDialog}
+        onClose={() => setOpenEditTitleDialog(false)}
+        aria-labelledby="edit-title-dialog"
+        >
+        <DialogTitle id="edit-title-dialog">Edit Title</DialogTitle>
+        <DialogContent>
+          <FormControl fullWidth>
+            <TextField
+              id="new-title"
+              value={newTitle}
+              onChange={(e) => setNewTitle(e.target.value)}
+              label="New Title"
+              variant="outlined"
+            />
+          </FormControl>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpenEditTitleDialog(false)} color="primary">
+            Cancel
+          </Button>
+          <Button onClick={handleUpdateTitle} color="primary">
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
       </Container>
     </Main>
   );

--- a/src/pages/InstructorRecordings/InstructorRecordings.jsx
+++ b/src/pages/InstructorRecordings/InstructorRecordings.jsx
@@ -231,7 +231,7 @@ const InstructorRecordings = () => {
   const handleUpdateTitle = () => {
     axios
       .patch(
-        `https://api.edukona.com/instructor-recordings/${selectedRecording}/update-title`,
+        `https://api.edukona.com/recordings/${selectedRecording}/update-title`,
         { title: newTitle },
         {
           headers: {

--- a/src/pages/InstructorRecordings/InstructorRecordings.jsx
+++ b/src/pages/InstructorRecordings/InstructorRecordings.jsx
@@ -24,7 +24,8 @@ import {
   CircularProgress,
   Slider,
   Grid,
-  FormControl, TextField,
+  FormControl,
+  TextField,
 } from '@mui/material';
 import axios from 'axios';
 import RecordButton from '../../blocks/RecordButton';
@@ -504,31 +505,31 @@ const InstructorRecordings = () => {
           </DialogActions>
         </Dialog>
         <Dialog
-        open={openEditTitleDialog}
-        onClose={() => setOpenEditTitleDialog(false)}
-        aria-labelledby="edit-title-dialog"
+          open={openEditTitleDialog}
+          onClose={() => setOpenEditTitleDialog(false)}
+          aria-labelledby="edit-title-dialog"
         >
-        <DialogTitle id="edit-title-dialog">Edit Title</DialogTitle>
-        <DialogContent>
-          <FormControl fullWidth>
-            <TextField
-              id="new-title"
-              value={newTitle}
-              onChange={(e) => setNewTitle(e.target.value)}
-              label="New Title"
-              variant="outlined"
-            />
-          </FormControl>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setOpenEditTitleDialog(false)} color="primary">
-            Cancel
-          </Button>
-          <Button onClick={handleUpdateTitle} color="primary">
-            Save
-          </Button>
-        </DialogActions>
-      </Dialog>
+          <DialogTitle id="edit-title-dialog">Edit Title</DialogTitle>
+          <DialogContent>
+            <FormControl fullWidth>
+              <TextField
+                id="new-title"
+                value={newTitle}
+                onChange={(e) => setNewTitle(e.target.value)}
+                label="New Title"
+                variant="outlined"
+              />
+            </FormControl>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setOpenEditTitleDialog(false)} color="primary">
+              Cancel
+            </Button>
+            <Button onClick={handleUpdateTitle} color="primary">
+              Save
+            </Button>
+          </DialogActions>
+        </Dialog>
       </Container>
     </Main>
   );

--- a/src/pages/InstructorRecordings/InstructorRecordings.jsx
+++ b/src/pages/InstructorRecordings/InstructorRecordings.jsx
@@ -555,32 +555,6 @@ const InstructorRecordings = () => {
             </Button>
           </DialogActions>
         </Dialog>
-        <Dialog
-          open={openEditTitleDialog}
-          onClose={() => setOpenEditTitleDialog(false)}
-          aria-labelledby="edit-title-dialog"
-        >
-          <DialogTitle id="edit-title-dialog">Edit Title</DialogTitle>
-          <DialogContent>
-            <FormControl fullWidth>
-              <TextField
-                id="new-title"
-                value={newTitle}
-                onChange={(e) => setNewTitle(e.target.value)}
-                label="New Title"
-                variant="outlined"
-              />
-            </FormControl>
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setOpenEditTitleDialog(false)} color="primary">
-              Cancel
-            </Button>
-            <Button onClick={handleUpdateTitle} color="primary">
-              Save
-            </Button>
-          </DialogActions>
-        </Dialog>
       </Container>
     </Main>
   );

--- a/src/pages/InstructorRecordings/InstructorRecordings.jsx
+++ b/src/pages/InstructorRecordings/InstructorRecordings.jsx
@@ -508,6 +508,35 @@ const InstructorRecordings = () => {
           open={openEditTitleDialog}
           onClose={() => setOpenEditTitleDialog(false)}
           aria-labelledby="edit-title-dialog"
+          maxWidth="sm"
+          fullWidth
+        >
+          <DialogTitle id="edit-title-dialog">Edit Title</DialogTitle>
+          <DialogContent>
+            <FormControl fullWidth>
+              <TextField
+                id="new-title"
+                value={newTitle}
+                onChange={(e) => setNewTitle(e.target.value)}
+                label="New Title"
+                variant="outlined"
+                fullWidth
+              />
+            </FormControl>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setOpenEditTitleDialog(false)} color="primary">
+              Cancel
+            </Button>
+            <Button onClick={handleUpdateTitle} color="primary">
+              Save
+            </Button>
+          </DialogActions>
+        </Dialog>
+        <Dialog
+          open={openEditTitleDialog}
+          onClose={() => setOpenEditTitleDialog(false)}
+          aria-labelledby="edit-title-dialog"
         >
           <DialogTitle id="edit-title-dialog">Edit Title</DialogTitle>
           <DialogContent>


### PR DESCRIPTION
This PR introduces an enhanced user experience for managing recordings by adding an 'Edit Title' functionality. Users can now easily update the title of their recordings directly from the customized menus. Below are the notable changes made:

### Changes:
- **Updated Imports:**
  - Added `EditIcon` import from Material UI icons in `CustomizedMenus.jsx`.

- **Enhanced Props Structure:**
  - Expanded the `CustomizedMenus` component to accept two new props: `setOpenEditTitleDialog` and `setNewTitle`, essential for handling the title editing feature.

- **Handle Edit Title Action:**
  - Implemented the `handleEditTitle` function, which opens the edit title dialog, sets the current recording's title to the input field, and closes the menu on selection.

- **New Menu Item:**
  - Added a new menu item labeled 'Edit Title' to the customized menu, incorporating `EditIcon` for visual representation and interaction.

- **Title Update Handling in InstructorRecordings Component:**
  - Managed component state to include `openEditTitleDialog` and `newTitle` for storing title editing information.
  - Introduced an `handleUpdateTitle` function responsible for sending a PATCH request to update the title in the backend. It handles success and error responses, providing user feedback through toast notifications.

- **Edit Title Dialog Component:**
  - Added a `Dialog` component that contains a `TextField` for entering the new title, along with `Cancel` and `Save` buttons for user actions.

### Benefits:
- Provides a more intuitive and interactive way for users to manage their recordings.
- Enhances the overall user experience by allowing quick edits directly from the menu.

This update is a significant step towards streamlining recording management, thus enabling instructors to maintain better organization over their recordings.