### PR TITLE
Add GenericMenu Component

### DIFF
--- a/src/blocks/GenericMenu.jsx
+++ b/src/blocks/GenericMenu.jsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import { styled, alpha } from '@mui/material/styles';
+import Button from '@mui/material/Button';
+import Menu from '@mui/material/Menu';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+
+const StyledMenu = styled((props) => (
+  <Menu
+    elevation={0}
+    anchorOrigin={{
+      vertical: 'bottom',
+      horizontal: 'right',
+    }}
+    transformOrigin={{
+      vertical: 'top',
+      horizontal: 'right',
+    }}
+    {...props}
+  />
+))(({ theme }) => ({
+  '& .MuiPaper-root': {
+    borderRadius: 6,
+    marginTop: theme.spacing(1),
+    minWidth: 180,
+    color: theme.palette.mode === 'light' ? 'rgb(55, 65, 81)' : theme.palette.grey[300],
+    boxShadow:
+      'rgb(255, 255, 255) 0px 0px 0px 0px, ' +
+      'rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, ' +
+      'rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, ' +
+      'rgba(0, 0, 0, 0.05) 0px 4px 6px -2px',
+    '& .MuiMenu-list': {
+      padding: '4px 0',
+    },
+    '& .MuiMenuItem-root': {
+      '& .MuiSvgIcon-root': {
+        fontSize: 18,
+        color: theme.palette.text.secondary,
+        marginRight: theme.spacing(1.5),
+      },
+      '&:active': {
+        backgroundColor: alpha(theme.palette.primary.main, theme.palette.action.selectedOpacity),
+      },
+    },
+  },
+}));
+
+export default function GenericMenu({ children, title }) {
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event) => {
+    event.stopPropagation(); // Prevent accordion from toggling
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = (event) => {
+    event.stopPropagation(); // Prevent accordion from toggling
+    setAnchorEl(null);
+  };
+
+  return (
+    <div>
+      <Button
+        id="action-button"
+        aria-controls={open ? 'customized-menu' : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        variant="contained"
+        disableElevation
+        onClick={handleClick}
+        endIcon={<KeyboardArrowDownIcon />}
+      >
+        {title}
+      </Button>
+      <StyledMenu
+        id="customized-menu"
+        MenuListProps={{
+          'aria-labelledby': 'action-button',
+        }}
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+      >
+        {children}
+      </StyledMenu>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR introduces a new `GenericMenu` component to the project. The component utilizes Material-UI's styling and menu components to create a customizable menu that can be used across the application.

### Key Changes:
- **New Component Creation**: 
  - Added a new file `GenericMenu.jsx` under the `src/blocks` directory.

- **Imports**: 
  - Imported necessary components from React and Material-UI, including `Button`, `Menu`, and `KeyboardArrowDownIcon`.

- **Styled Menu Component**:
  - Created a customized `StyledMenu` using Material-UI's `styled` API to allow for additional styling.
  - Defined styles for:
    - Paper root (borderRadius, margin, minWidth, color, boxShadow).
    - Menu items (padding and active state styles).

- **State Management**:
  - Implemented local state using `React.useState` to manage the anchor element of the menu.
  - Handled menu open/close functionality through `handleClick` and `handleClose` methods, ensuring proper toggling without affecting adjacent components.

- **Accessibility Features**:
  - Added appropriate ARIA attributes to the button and the menu to improve accessibility for screen readers.

- **Button Configuration**:
  - Configured a Material-UI `<Button>` component that triggers the menu, complete with an icon and title prop to display text.

### Usage:
- The `GenericMenu` component can be imported and used in other components, allowing developers to pass children elements as menu items and a title for the button.

### Example:
This is a screenshot of the menu in action on a quiz  list row item. The use of the menu on the quiz items will be introduced in a separate PR.
![menu](https://github.com/user-attachments/assets/4454caaf-4e1a-4563-9973-2d9585519715)
