### PR TITLE
Enhance Incorrect Answers Display in EditQuizView

### DIFF
--- a/src/pages/EditQuizView.jsx
+++ b/src/pages/EditQuizView.jsx
@@ -329,7 +329,16 @@ function EditQuizView() {
               </h3>
               <p style={labelStyle}>Points: {question.points}</p>
               <p style={labelStyle}>Correct Answer: {question.correct_answer}</p>
-              <p style={labelStyle}>Incorrect Answers: {question.incorrect_answer_list.join(', ')}</p>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '2px', justifyContent: 'start' }}>
+                <p style={labelStyle}>
+                  <strong>Incorrect Answers:</strong>
+                  {question.incorrect_answer_list.map((incorrectAnswer) => (
+                    <p>
+                      Answer: {incorrectAnswer.answer} <br /> Feedback: {incorrectAnswer.feedback}
+                    </p>
+                  ))}
+                </p>
+              </div>
               <Button
                 size={'large'}
                 variant={'contained'}


### PR DESCRIPTION
This pull request implements an improved rendering of incorrect answers for quizzes in the EditQuizView component. The changes are aimed at providing clearer information and better organization of incorrect answers, including associated feedback. The modifications made include the following:

- **Revised Incorrect Answers Section**: 
  - Previous display method for incorrect answers was updated from a single line to a more structured layout.
  - Each incorrect answer now displays both the answer and its associated feedback, enhancing clarity for users.
  - The styling has been adjusted to use a flexbox layout, making the components easier to read.

- **Improved User Experience**:
  - By separating each incorrect answer into its own paragraph, users can quickly identify and review feedback provided for each answer.
  - The layout adjustments (e.g., flex direction, gap) improve the visual presentation of the incorrect answers, contributing to a more organized interface.

Overall, these changes aim to enhance the usability of the EditQuizView by providing quiz editors with clearer and more informative displays for incorrect answers.

*Example of feedback display*:
![feedback-display](https://github.com/user-attachments/assets/d0950aed-f2a2-427b-892d-32880887ae1c)
