### PR TITLE
Enhance Quiz and Recording List UI to Handle Empty States

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17296,6 +17296,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.0.1.tgz",
       "integrity": "sha512-186Gw/vF1uRkydbsOIkcGXw7aHq0sZOCRFFjGrr7b9+nVZg4UfA4enXCaxm4fUzecU38sWfrNDitGhshuU7rdg==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",

--- a/src/blocks/QuizList.jsx
+++ b/src/blocks/QuizList.jsx
@@ -22,9 +22,11 @@ const QuizList = () => {
     <TableContainer component={Paper}>
       <Table>
         <TableBody>
-          {quizzes.map((quiz) => (
-            <QuizListRow key={quiz.id} quiz={quiz} onUpdate={onUpdate} />
-          ))}
+          {quizzes.length === 0 ? (
+            <h1 style={{ textAlign: 'center' }}>No Quizzes</h1>
+          ) : (
+            quizzes.map((quiz) => <QuizListRow key={quiz.id} quiz={quiz} onUpdate={onUpdate} />)
+          )}
         </TableBody>
       </Table>
     </TableContainer>

--- a/src/pages/InstructorRecordings/InstructorRecordings.jsx
+++ b/src/pages/InstructorRecordings/InstructorRecordings.jsx
@@ -288,111 +288,115 @@ const InstructorRecordings = () => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {recordings.map((recording) => (
-                <React.Fragment key={recording.id}>
-                  {/* First Row: Recording Details */}
-                  <TableRow sx={{ cursor: 'default' }}>
-                    {/* Adjusted alignment to center */}
-                    <TableCell align="center" sx={{ width: '25%' }}>
-                      {/* Center the content inside */}
-                      <Box textAlign="center">
-                        {/* Accordion Summary */}
-                        <Accordion
-                          expanded={expanded === recording.id}
-                          onChange={handleAccordionChange(recording.id)}
-                          sx={{ boxShadow: 'none' }}
-                        >
-                          <AccordionSummary
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleAccordionChange(recording.id)(e, expanded !== recording.id);
-                            }}
-                            aria-controls={`panel-${recording.id}-content`}
-                            id={`panel-${recording.id}-header`}
-                            sx={{ padding: 0 }}
+              {recordings.length === 0 ? (
+                <h1 style={{ textAlign: 'center' }}>No Recordings</h1>
+              ) : (
+                recordings.map((recording) => (
+                  <React.Fragment key={recording.id}>
+                    {/* First Row: Recording Details */}
+                    <TableRow sx={{ cursor: 'default' }}>
+                      {/* Adjusted alignment to center */}
+                      <TableCell align="center" sx={{ width: '25%' }}>
+                        {/* Center the content inside */}
+                        <Box textAlign="center">
+                          {/* Accordion Summary */}
+                          <Accordion
+                            expanded={expanded === recording.id}
+                            onChange={handleAccordionChange(recording.id)}
+                            sx={{ boxShadow: 'none' }}
                           >
-                            <Button
-                              color="primary"
+                            <AccordionSummary
                               onClick={(e) => {
                                 e.stopPropagation();
-                                handleTitleClick(recording.id, recording.title);
+                                handleAccordionChange(recording.id)(e, expanded !== recording.id);
                               }}
+                              aria-controls={`panel-${recording.id}-content`}
+                              id={`panel-${recording.id}-header`}
+                              sx={{ padding: 0 }}
                             >
-                              {recording.title === '' ? recording.id.substr(0, 7) + '...' : recording.title}
-                            </Button>
-                          </AccordionSummary>
-                        </Accordion>
-                      </Box>
-                    </TableCell>
-                    <TableCell align="center" sx={{ width: '25%' }}>
-                      {new Date(recording.uploaded_at).toLocaleDateString(undefined, {
-                        year: 'numeric',
-                        month: 'long',
-                        day: 'numeric',
-                        hour: 'numeric',
-                        minute: 'numeric',
-                      })}
-                    </TableCell>
-                    <TableCell align="center" sx={{ width: '25%' }}>
-                      <Box
-                        component="span"
-                        sx={{
-                          width: 16,
-                          height: 16,
-                          display: 'inline-block',
-                          borderRadius: '50%',
-                          bgcolor: recording.transcript.toLowerCase() === 'completed' ? 'green' : 'red',
-                          marginRight: 1,
-                        }}
-                      />
-                      {recording.transcript.charAt(0).toUpperCase() + recording.transcript.slice(1)}
-                    </TableCell>
-                    {/* Adjusted alignment to center */}
-                    <TableCell align="center" sx={{ width: '25%' }}>
-                      {/* Center the CustomizedMenus component */}
-                      <Box textAlign="center">
-                        <CustomizedMenus
-                          recording={recording}
-                          handleOpenDialogue={handleOpenDialogue}
-                          setSelectedRecording={setSelectedRecording}
-                          setOpenNewRecording={setOpenNewRecording}
-                          setOpenEditTitleDialog={setOpenEditTitleDialog}
-                          handleGenerateSummary={handleGenerateSummary}
-                          setNewTitle={setNewTitle}
+                              <Button
+                                color="primary"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleTitleClick(recording.id, recording.title);
+                                }}
+                              >
+                                {recording.title === '' ? recording.id.substr(0, 7) + '...' : recording.title}
+                              </Button>
+                            </AccordionSummary>
+                          </Accordion>
+                        </Box>
+                      </TableCell>
+                      <TableCell align="center" sx={{ width: '25%' }}>
+                        {new Date(recording.uploaded_at).toLocaleDateString(undefined, {
+                          year: 'numeric',
+                          month: 'long',
+                          day: 'numeric',
+                          hour: 'numeric',
+                          minute: 'numeric',
+                        })}
+                      </TableCell>
+                      <TableCell align="center" sx={{ width: '25%' }}>
+                        <Box
+                          component="span"
+                          sx={{
+                            width: 16,
+                            height: 16,
+                            display: 'inline-block',
+                            borderRadius: '50%',
+                            bgcolor: recording.transcript.toLowerCase() === 'completed' ? 'green' : 'red',
+                            marginRight: 1,
+                          }}
                         />
-                      </Box>
-                    </TableCell>
-                  </TableRow>
-                  {/* Second Row: Accordion Details */}
-                  {expanded === recording.id && (
-                    <TableRow>
-                      <TableCell colSpan={4} style={{ paddingBottom: 0, paddingTop: 0 }}>
-                        <Accordion expanded={expanded === recording.id} sx={{ boxShadow: 'none' }}>
-                          <AccordionDetails>
-                            {loadingQuizzes ? (
-                              <CircularProgress />
-                            ) : quizzes.length === 0 ? (
-                              <Typography>No quizzes available</Typography>
-                            ) : (
-                              <Table>
-                                <TableBody>
-                                  {quizzes.map((quiz) => (
-                                    <QuizListRow
-                                      key={quiz.id}
-                                      quiz={quiz}
-                                      onUpdate={() => fetchQuizzes(recording.id)}
-                                    />
-                                  ))}
-                                </TableBody>
-                              </Table>
-                            )}
-                          </AccordionDetails>
-                        </Accordion>
+                        {recording.transcript.charAt(0).toUpperCase() + recording.transcript.slice(1)}
+                      </TableCell>
+                      {/* Adjusted alignment to center */}
+                      <TableCell align="center" sx={{ width: '25%' }}>
+                        {/* Center the CustomizedMenus component */}
+                        <Box textAlign="center">
+                          <CustomizedMenus
+                            recording={recording}
+                            handleOpenDialogue={handleOpenDialogue}
+                            setSelectedRecording={setSelectedRecording}
+                            setOpenNewRecording={setOpenNewRecording}
+                            setOpenEditTitleDialog={setOpenEditTitleDialog}
+                            handleGenerateSummary={handleGenerateSummary}
+                            setNewTitle={setNewTitle}
+                          />
+                        </Box>
                       </TableCell>
                     </TableRow>
-                  )}
-                </React.Fragment>
-              ))}
+                    {/* Second Row: Accordion Details */}
+                    {expanded === recording.id && (
+                      <TableRow>
+                        <TableCell colSpan={4} style={{ paddingBottom: 0, paddingTop: 0 }}>
+                          <Accordion expanded={expanded === recording.id} sx={{ boxShadow: 'none' }}>
+                            <AccordionDetails>
+                              {loadingQuizzes ? (
+                                <CircularProgress />
+                              ) : quizzes.length === 0 ? (
+                                <Typography>No quizzes available</Typography>
+                              ) : (
+                                <Table>
+                                  <TableBody>
+                                    {quizzes.map((quiz) => (
+                                      <QuizListRow
+                                        key={quiz.id}
+                                        quiz={quiz}
+                                        onUpdate={() => fetchQuizzes(recording.id)}
+                                      />
+                                    ))}
+                                  </TableBody>
+                                </Table>
+                              )}
+                            </AccordionDetails>
+                          </Accordion>
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </React.Fragment>
+                ))
+              )}
             </TableBody>
           </Table>
         </TableContainer>


### PR DESCRIPTION
KAN-197
This pull request introduces improvements to the `QuizList` and `InstructorRecordings` components, specifically in handling cases where there are no quizzes or recordings available. The updates enhance user experience by clearly indicating empty states. 

## Changes Made:

### `QuizList.jsx`
- **Empty State Handling**:
  - Added a condition to check if the `quizzes` array is empty.
  - If empty, a centered message `No Quizzes` is displayed to inform the user.
  - This prevents rendering an empty list and provides a clearer communication to the user.

### `InstructorRecordings.jsx`
- **Empty State Handling**:
  - Introduced similar logic for handling recordings by checking if the `recordings` array is empty.
  - If empty, a centered message `No Recordings` is displayed to inform the user.
  - Users will now see a clear message instead of an empty table.

### Code Structure Improvements:
- **Rendering Logic**:
  - Updated the rendering logic for both quizzes and recordings to make the code more readable.
  - Introduced ternary operators to streamline conditions, ensuring clarity and maintainability.

These enhancements ensure that users are properly informed when there are no quizzes or recordings available, leading to a better user interface and experience.