### PR TITLE
KAN-219: Add Delete Recording Dialog Component

### DIFF
--- a/src/blocks/DeleteRecordingDialog.jsx
+++ b/src/blocks/DeleteRecordingDialog.jsx
@@ -1,0 +1,40 @@
+import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
+import { toast } from 'react-toastify';
+import { deleteRecording } from '../services/apiService';
+
+const DeleteRecordingDialog = ({ open, setOpen, onUpdate, recordingId }) => {
+  const handleDeleteRecording = () => {
+    deleteRecording(recordingId)
+      .then(() => {
+        toast.success('Recording successfully deleted!');
+        onUpdate();
+        setOpen(false);
+      })
+      .catch(() => toast.error('Failed to delete recording.'));
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => setOpen(false)}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+    >
+      <DialogTitle id="alert-dialog-title">{'Confirm Deletion'}</DialogTitle>
+      <DialogContent>
+        <DialogContentText id="alert-dialog-description">
+          Are you sure you want to delete this recording?
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => setOpen(false)} color="primary">
+          Cancel
+        </Button>
+        <Button onClick={handleDeleteRecording} color="primary" autoFocus>
+          Confirm
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+export default DeleteRecordingDialog;

--- a/src/pages/InstructorRecordings/InstructorRecordings.jsx
+++ b/src/pages/InstructorRecordings/InstructorRecordings.jsx
@@ -373,7 +373,7 @@ const InstructorRecordings = () => {
                     {/* Dialog for delete confirmation */}
                     <DeleteRecordingDialog
                       open={openDialogue}
-                      setOpen={handleOpenDialogue}
+                      setOpen={setOpenDialogue}
                       onUpdate={handleFetchRecordings}
                       recordingId={recording.id}
                     />

--- a/src/pages/InstructorRecordings/InstructorRecordings.jsx
+++ b/src/pages/InstructorRecordings/InstructorRecordings.jsx
@@ -35,6 +35,7 @@ import { Main } from '../../layouts';
 import { useNavigate } from 'react-router-dom';
 import CustomizedMenus from '../../blocks/CustomizedMenus';
 import { fetchRecordings, deleteRecording, startQuizSession } from '../../services/apiService';
+import DeleteRecordingDialog from '../../blocks/DeleteRecordingDialog';
 
 const InstructorRecordings = () => {
   const [openNewRecording, setOpenNewRecording] = useState(false);
@@ -270,7 +271,13 @@ const InstructorRecordings = () => {
             </TableHead>
             <TableBody>
               {recordings.length === 0 ? (
-                <h1 style={{ textAlign: 'center' }}>No Recordings</h1>
+                <TableRow>
+                  <TableCell colSpan={4}>
+                    <Typography variant={'h4'} textAlign={'center'}>
+                      No Recordings
+                    </Typography>
+                  </TableCell>
+                </TableRow>
               ) : (
                 recordings.map((recording) => (
                   <React.Fragment key={recording.id}>
@@ -375,34 +382,19 @@ const InstructorRecordings = () => {
                         </TableCell>
                       </TableRow>
                     )}
+                    {/* Dialog for delete confirmation */}
+                    <DeleteRecordingDialog
+                      open={openDialogue}
+                      setOpen={handleOpenDialogue}
+                      onUpdate={handleFetchRecordings}
+                      recordingId={recording.id}
+                    />
                   </React.Fragment>
                 ))
               )}
             </TableBody>
           </Table>
         </TableContainer>
-        {/* Dialog for delete confirmation */}
-        <Dialog
-          open={openDialogue}
-          onClose={() => setOpenDialogue(false)}
-          aria-labelledby="alert-dialog-title"
-          aria-describedby="alert-dialog-description"
-        >
-          <DialogTitle id="alert-dialog-title">{'Confirm Deletion'}</DialogTitle>
-          <DialogContent>
-            <DialogContentText id="alert-dialog-description">
-              Are you sure you want to delete this recording?
-            </DialogContentText>
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setOpenDialogue(false)} color="primary">
-              Cancel
-            </Button>
-            <Button onClick={handleDeleteRecording} color="primary" autoFocus>
-              Confirm
-            </Button>
-          </DialogActions>
-        </Dialog>
         {/* Dialog for creating a new quiz */}
         <Dialog
           open={openNewRecording}

--- a/src/pages/InstructorRecordings/InstructorRecordings.jsx
+++ b/src/pages/InstructorRecordings/InstructorRecordings.jsx
@@ -13,8 +13,6 @@ import {
   Button,
   Dialog,
   DialogContent,
-  DialogTitle,
-  DialogContentText,
   DialogActions,
   Snackbar,
   Alert,
@@ -34,7 +32,7 @@ import { toast } from 'react-toastify';
 import { Main } from '../../layouts';
 import { useNavigate } from 'react-router-dom';
 import CustomizedMenus from '../../blocks/CustomizedMenus';
-import { fetchRecordings, deleteRecording, startQuizSession } from '../../services/apiService';
+import { fetchRecordings, startQuizSession } from '../../services/apiService';
 import DeleteRecordingDialog from '../../blocks/DeleteRecordingDialog';
 
 const InstructorRecordings = () => {
@@ -89,16 +87,6 @@ const InstructorRecordings = () => {
 
   const handleFetchRecordings = () => {
     fetchRecordings().then((res) => setRecordings(res.data.recordings));
-  };
-
-  const handleDeleteRecording = () => {
-    deleteRecording(selectedRecording).then((res) => {
-      res.status === 200
-        ? toast.success('Recording successfully deleted!', { icon: '🗑️', theme })
-        : toast.error('Could not delete recording.', { theme });
-      handleFetchRecordings();
-      setOpenDialogue(false);
-    });
   };
 
   const handleGenerateSummary = (recordingId) => {


### PR DESCRIPTION
This PR introduces a new component for deleting recordings, enhancing the user interface and experience. The following changes have been made:

### New Features:
- **DeleteRecordingDialog Component**: A new modal dialog for confirming recording deletions has been created with the following features:
  - Uses Material-UI components for consistent styling and functionality.
  - Displays a confirmation message asking users to confirm deletion.
  - Integrates success/error notifications with `react-toastify` upon deletion action.
  - Calls `deleteRecording` from the API service to handle the delete operation.

### Modifications:
- **InstructorRecordings Page**: 
  - Imported the `DeleteRecordingDialog` component.
  - Removed the inline deletion confirmation dialog code and replaced it with the new reusable `DeleteRecordingDialog` component.
  - Ensured `open`, `setOpen`, `onUpdate`, and `recordingId` props are correctly passed to the `DeleteRecordingDialog`, enhancing reusability and maintainability of the code.
- **Styling and Formatting**: 
  - Adjusted the layout of the empty recordings message from an `<h1>` element to a `<Typography>` component from Material-UI for better styling.

### Benefits:
- The introduction of the dialog component separates concerns, allowing easier maintenance and potential reuse in the future.
- Makes the code cleaner and improves the user interface experience during the deletion process.