### PR TITLE
Update nginx commands in AWS Elastic Beanstalk config

### DIFF
--- a/.ebextensions/https-single-instance.config
+++ b/.ebextensions/https-single-instance.config
@@ -57,5 +57,9 @@ files:
 container_commands:
   00_debug_log:
     command: "echo '.ebextensions script running' >> /var/log/ebextensions-debug.log"
-  01_reload_nginx:
+
+  01_start_nginx:
+    command: "systemctl start nginx"
+
+  02_reload_nginx:
     command: "service nginx reload >> /var/log/ebextensions-debug.log 2>&1"


### PR DESCRIPTION
Renamed the command to start nginx explicitly before reloading it. This ensures nginx is running before attempting a reload, preventing errors during deployment.