### PR TITLE
# Refactor DeleteQuestionDialog to Use API Service

### DIFF
--- a/src/blocks/DeleteQuestionDialog.jsx
+++ b/src/blocks/DeleteQuestionDialog.jsx
@@ -1,17 +1,15 @@
 import { Delete, Undo } from '@mui/icons-material';
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Typography } from '@mui/material';
-import axios from 'axios';
 import { toast } from 'react-toastify';
+import { deleteQuestion } from '../services/apiService';
 
-const DeleteQuestionDialog = ({ question, token, open, setOpen, onUpdate }) => {
+const DeleteQuestionDialog = ({ question, open, setOpen, onUpdate }) => {
   const handleDelete = () =>
     toast.promise(
-      axios
-        .delete(`https://api.edukona.com/question/${question.id}/`, { headers: { Authorization: `Token ${token}` } })
-        .then(() => {
-          setOpen(false);
-          onUpdate();
-        }),
+      deleteQuestion(question.id).then(() => {
+        setOpen(false);
+        onUpdate();
+      }),
       {
         pending: 'Deleting question...',
         success: 'Successfully deleted question.',

--- a/src/blocks/EditableQuestion.jsx
+++ b/src/blocks/EditableQuestion.jsx
@@ -5,6 +5,7 @@ import axios from 'axios';
 import { useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
 import DeleteQuestionDialog from './DeleteQuestionDialog';
+import { editQuestion } from '../services/apiService';
 
 const EditableQuestion = ({ question, token, onUpdate }) => {
   const [questionData, setQuestionData] = useState(question);
@@ -32,14 +33,10 @@ const EditableQuestion = ({ question, token, onUpdate }) => {
   const handleSave = (e) => {
     e.preventDefault();
     toast.promise(
-      axios
-        .put(`https://api.edukona.com/question/${question.id}/`, questionData, {
-          headers: { Authorization: `Token ${token}` },
-        })
-        .then(() => {
-          setDisabled(true);
-          onUpdate();
-        }),
+      editQuestion(questionData.id, questionData).then(() => {
+        setDisabled(true);
+        onUpdate();
+      }),
       { pending: 'Saving changes...', success: 'Successfully saved changes', error: 'Failed to save changes' }
     );
   };

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -67,6 +67,7 @@ export const JWTSignUpInstructor = (formData) => api.post('jwt-sign-up-instructo
 export const googleAuth = (token) => api.post('auth/jwt-google/', { token });
 export const logout = (refreshToken) => api.post('jwt-logout/', { refresh: refreshToken });
 export const deleteQuestion = (questionId) => api.delete(`question/${questionId}`);
+export const editQuestion = (questionId, data) => api.put(`question/${questionId}/`, data);
 
 export const fetchQuizzes = () =>
   api.get('instructor/quizzes/', {

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -61,12 +61,12 @@ api.interceptors.response.use(
   }
 );
 
-// jwt-related api calls
 export const login = (email, password) =>
   api.post('jwt-login/', { email, password }, { headers: { Authorization: '' } });
 export const JWTSignUpInstructor = (formData) => api.post('jwt-sign-up-instructor/', formData);
 export const googleAuth = (token) => api.post('auth/jwt-google/', { token });
 export const logout = (refreshToken) => api.post('jwt-logout/', { refresh: refreshToken });
+export const deleteQuestion = (questionId) => api.delete(`question/${questionId}`);
 
 export const fetchQuizzes = () =>
   api.get('instructor/quizzes/', {


### PR DESCRIPTION
KAN-262
This pull request refactors the `DeleteQuestionDialog` component to use a dedicated API service for deleting questions. The following changes have been made:

- **Removed axios import**: The axios library is no longer directly imported in the `DeleteQuestionDialog.jsx` file, promoting a cleaner separation of concerns.
- **Introduced deleteQuestion service**: A new service method `deleteQuestion` has been added to the `apiService.js` file. This method encapsulates the API call to delete a question, improving code readability and maintainability.
- **Updated handleDelete method**: The `handleDelete` function in the `DeleteQuestionDialog` now uses the new `deleteQuestion` method to handle deletion operations, enhancing the modularity of the code.
- **Removed token dependency**: The token parameter has been removed from the `DeleteQuestionDialog` component since the authorization header is now managed within the API service, simplifying the component's props.
- **Toast notifications**: The promise handling for toast notifications remains unchanged but now calls the new service method, ensuring the user is informed of deletion status.

This refactor sets the groundwork for further enhancements and a more streamlined API interaction in the application.