### PR TITLE
KAN-240: Refactor AccordionQuizzes component and implement RecordingListRow

### DIFF
--- a/src/pages/InstructorRecordings/Components/AccordionQuizzes.tsx
+++ b/src/pages/InstructorRecordings/Components/AccordionQuizzes.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import {
   Accordion,
   AccordionSummary,
@@ -20,12 +20,23 @@ interface Quiz {
 interface AccordionQuizzesProps {
   recordingId: string;
   expanded: boolean;
-  onChange: (event: React.SyntheticEvent, isExpanded: boolean) => void;
 }
 
-const AccordionQuizzes: FC<AccordionQuizzesProps> = ({ recordingId, expanded, onChange }) => {
+const AccordionQuizzes: FC<AccordionQuizzesProps> = ({ recordingId, expanded }) => {
   const [quizzes, setQuizzes] = useState<Quiz[] | null>(null);
   const [loading, setLoading] = useState(false);
+
+  const handleFetchQuizzes = () =>
+    fetchQuizzesByRecording(recordingId)
+      .then((res) => {
+        setQuizzes(res.data);
+      })
+      .catch((error) => {
+        console.error('Error fetching quizzes:', error);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
 
   useEffect(() => {
     // If the accordion isn't expanded, don't do anything
@@ -34,21 +45,12 @@ const AccordionQuizzes: FC<AccordionQuizzesProps> = ({ recordingId, expanded, on
     // Only fetch quizzes the first time the accordion is expanded
     if (quizzes === null) {
       setLoading(true);
-      fetchQuizzesByRecording(recordingId)
-        .then((res) => {
-          setQuizzes(res.data);
-        })
-        .catch((error) => {
-          console.error('Error fetching quizzes:', error);
-        })
-        .finally(() => {
-          setLoading(false);
-        });
+      handleFetchQuizzes();
     }
   }, [expanded, quizzes, recordingId]);
 
   return (
-    <Accordion expanded={expanded} onChange={onChange} sx={{ boxShadow: 'none' }}>
+    <Accordion expanded={expanded} sx={{ boxShadow: 'none' }}>
       <AccordionSummary sx={{ padding: 0 }}>
         <Typography variant="subtitle1" sx={{ ml: 1 }}>
           Quizzes
@@ -64,7 +66,7 @@ const AccordionQuizzes: FC<AccordionQuizzesProps> = ({ recordingId, expanded, on
           <Table>
             <TableBody>
               {quizzes.map((quiz) => (
-                <QuizListRow key={quiz.id} quiz={quiz} onUpdate={() => {}} />
+                <QuizListRow key={quiz.id} quiz={quiz} onUpdate={handleFetchQuizzes} />
               ))}
             </TableBody>
           </Table>

--- a/src/pages/InstructorRecordings/Components/RecordingListRow.tsx
+++ b/src/pages/InstructorRecordings/Components/RecordingListRow.tsx
@@ -1,0 +1,68 @@
+import { Box, Button, TableCell, TableRow } from '@mui/material';
+import React, { useState } from 'react';
+import RecordingListRowMenu from '../../../blocks/RecordingListRowMenu';
+import { Recording } from '../../../types/edukonaTypes';
+import AccordionQuizzes from './AccordionQuizzes';
+
+const RecordingListRow = ({ recording, onUpdate }: { recording: Recording; onUpdate: () => void }) => {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <React.Fragment key={recording.id}>
+      {/* --- Row 1: Recording Info --- */}
+      <TableRow sx={{ cursor: 'default' }}>
+        <TableCell align="center" sx={{ width: '25%' }}>
+          <Box textAlign="center">
+            <Button
+              color="primary"
+              onClick={(e) => {
+                e.stopPropagation();
+                setExpanded(!expanded);
+              }}
+            >
+              {recording.title === '' ? recording.id.substring(0, 7) + '...' : recording.title}
+            </Button>
+          </Box>
+        </TableCell>
+        <TableCell align="center" sx={{ width: '25%' }}>
+          {new Date(recording.uploaded_at).toLocaleDateString(undefined, {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: 'numeric',
+          })}
+        </TableCell>
+        <TableCell align="center" sx={{ width: '25%' }}>
+          <Box
+            component="span"
+            sx={{
+              width: 16,
+              height: 16,
+              display: 'inline-block',
+              borderRadius: '50%',
+              bgcolor: recording.transcript.toLowerCase() === 'completed' ? 'green' : 'red',
+              marginRight: 1,
+            }}
+          />
+          {recording.transcript.charAt(0).toUpperCase() + recording.transcript.slice(1)}
+        </TableCell>
+        <TableCell align="center" sx={{ width: '25%' }}>
+          <Box textAlign="center">
+            <RecordingListRowMenu recording={recording} onUpdate={onUpdate} />
+          </Box>
+        </TableCell>
+      </TableRow>
+
+      {/* --- Row 2: Accordion for Quizzes (only if expanded) --- */}
+      {expanded && (
+        <TableRow>
+          <TableCell colSpan={4} style={{ paddingBottom: 0, paddingTop: 0 }}>
+            <AccordionQuizzes recordingId={recording.id} expanded={expanded} />
+          </TableCell>
+        </TableRow>
+      )}
+    </React.Fragment>
+  );
+};
+
+export default RecordingListRow;

--- a/src/pages/InstructorRecordings/InstructorRecordings.jsx
+++ b/src/pages/InstructorRecordings/InstructorRecordings.jsx
@@ -9,6 +9,8 @@ import {
   TableRow,
   Paper,
   Typography,
+  CircularProgress,
+  Box,
 } from '@mui/material';
 import RecordButton from '../../blocks/RecordButton';
 import { toast } from 'react-toastify';
@@ -19,13 +21,15 @@ import { useRecordingWebSocket } from '../../services/apiService';
 import RecordingListRow from './Components/RecordingListRow';
 
 const InstructorRecordings = () => {
+  const [loading, setLoading] = useState(true);
   const [recordings, setRecordings] = useState([]);
   const navigate = useNavigate();
 
   // Fetch recordings
-  const handleFetchRecordings = () => {
-    fetchRecordings().then((res) => setRecordings(res.data.recordings));
-  };
+  const handleFetchRecordings = () =>
+    fetchRecordings()
+      .then((res) => setRecordings(res.data.recordings))
+      .finally(() => setLoading(false));
 
   // WebSocket events
   const handleIncomingMessage = (event) => {
@@ -95,7 +99,13 @@ const InstructorRecordings = () => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {recordings.length === 0 ? (
+              {loading ? (
+                <TableRow>
+                  <TableCell colSpan={4} align={'center'}>
+                    <CircularProgress />
+                  </TableCell>
+                </TableRow>
+              ) : recordings.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={4}>
                     <Typography variant={'h4'} textAlign={'center'}>

--- a/src/pages/InstructorRecordings/InstructorRecordings.jsx
+++ b/src/pages/InstructorRecordings/InstructorRecordings.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Container,
   Table,
@@ -9,25 +9,17 @@ import {
   TableRow,
   Paper,
   Typography,
-  Box,
-  Button,
 } from '@mui/material';
 import RecordButton from '../../blocks/RecordButton';
 import { toast } from 'react-toastify';
 import { Main } from '../../layouts';
 import { useNavigate } from 'react-router-dom';
 import { fetchRecordings, startQuizSession } from '../../services/apiService';
-import RecordingListRowMenu from '../../blocks/RecordingListRowMenu';
 import { useRecordingWebSocket } from '../../services/apiService';
-
-// Import our new component
-import AccordionQuizzes from './Components/AccordionQuizzes.tsx';
+import RecordingListRow from './Components/RecordingListRow';
 
 const InstructorRecordings = () => {
   const [recordings, setRecordings] = useState([]);
-  const token = useRef(localStorage.getItem('token') || '');
-  const theme = localStorage.getItem('themeMode');
-  const [expanded, setExpanded] = useState(null);
   const navigate = useNavigate();
 
   // Fetch recordings
@@ -72,32 +64,6 @@ const InstructorRecordings = () => {
     handleFetchRecordings();
   }, []);
 
-  /**
-   * Toggles the accordion for a given recording ID.
-   * If it's already expanded, collapse it; otherwise expand it.
-   */
-  const handleAccordionChange = (recordingId) => (event, isExpanded) => {
-    setExpanded(isExpanded ? recordingId : null);
-  };
-
-  const handleTitleClick = (recordingId, recordingTitle) => {
-    // If the recording has no title, copy the ID to clipboard
-    if (recordingTitle === '') {
-      navigator.permissions.query({ name: 'clipboard-write' }).then((result) => {
-        if (result.state === 'granted' || result.state === 'prompt') {
-          toast.promise(navigator.clipboard.writeText(recordingId), {
-            success: 'Copied recording id to clipboard',
-            pending: 'Copying recording id to clipboard',
-            error: "Couldn't copy recording id to clipboard",
-            theme,
-          });
-        }
-      });
-    }
-    // Toggle the accordion
-    setExpanded(expanded === recordingId ? null : recordingId);
-  };
-
   return (
     <Main>
       <Container sx={{ padding: '40px' }}>
@@ -139,66 +105,7 @@ const InstructorRecordings = () => {
                 </TableRow>
               ) : (
                 recordings.map((recording) => (
-                  <React.Fragment key={recording.id}>
-                    {/* --- Row 1: Recording Info --- */}
-                    <TableRow sx={{ cursor: 'default' }}>
-                      <TableCell align="center" sx={{ width: '25%' }}>
-                        <Box textAlign="center">
-                          <Button
-                            color="primary"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleTitleClick(recording.id, recording.title);
-                            }}
-                          >
-                            {recording.title === '' ? recording.id.substr(0, 7) + '...' : recording.title}
-                          </Button>
-                        </Box>
-                      </TableCell>
-                      <TableCell align="center" sx={{ width: '25%' }}>
-                        {new Date(recording.uploaded_at).toLocaleDateString(undefined, {
-                          year: 'numeric',
-                          month: 'long',
-                          day: 'numeric',
-                          hour: 'numeric',
-                          minute: 'numeric',
-                        })}
-                      </TableCell>
-                      <TableCell align="center" sx={{ width: '25%' }}>
-                        <Box
-                          component="span"
-                          sx={{
-                            width: 16,
-                            height: 16,
-                            display: 'inline-block',
-                            borderRadius: '50%',
-                            bgcolor: recording.transcript.toLowerCase() === 'completed' ? 'green' : 'red',
-                            marginRight: 1,
-                          }}
-                        />
-                        {recording.transcript.charAt(0).toUpperCase() + recording.transcript.slice(1)}
-                      </TableCell>
-                      <TableCell align="center" sx={{ width: '25%' }}>
-                        <Box textAlign="center">
-                          <RecordingListRowMenu recording={recording} onUpdate={handleFetchRecordings} />
-                        </Box>
-                      </TableCell>
-                    </TableRow>
-
-                    {/* --- Row 2: Accordion for Quizzes (only if expanded) --- */}
-                    {expanded === recording.id && (
-                      <TableRow>
-                        <TableCell colSpan={4} style={{ paddingBottom: 0, paddingTop: 0 }}>
-                          <AccordionQuizzes
-                            recordingId={recording.id}
-                            token={token.current}
-                            expanded={expanded === recording.id}
-                            onChange={handleAccordionChange(recording.id)}
-                          />
-                        </TableCell>
-                      </TableRow>
-                    )}
-                  </React.Fragment>
+                  <RecordingListRow key={recording.id} recording={recording} onUpdate={handleFetchRecordings} />
                 ))
               )}
             </TableBody>

--- a/src/pages/InstructorRecordings/InstructorRecordings.jsx
+++ b/src/pages/InstructorRecordings/InstructorRecordings.jsx
@@ -10,7 +10,6 @@ import {
   Paper,
   Typography,
   CircularProgress,
-  Box,
 } from '@mui/material';
 import RecordButton from '../../blocks/RecordButton';
 import { toast } from 'react-toastify';


### PR DESCRIPTION
This pull request includes significant refactoring of the AccordionQuizzes component and introduces a new RecordingListRow component for better organization and clarity. The following changes were made:

### Changes to AccordionQuizzes Component:
- **Removed Prop `onChange`:** The `onChange` prop is no longer necessary and has been removed from the `AccordionQuizzesProps` interface.
- **Introduced `handleFetchQuizzes` Method:** A new method to handle fetching quizzes from the API was added. This centralizes the fetching logic.
- **Simplified `useEffect` Logic:** The effect now only checks if the accordion is expanded and fetches quizzes only if they have not been loaded previously.
- **Use Fetch Method Directly in `useEffect`:** The previous fetch logic was moved into the new `handleFetchQuizzes` method to keep the effect cleaner.
- **Linked `onUpdate` in `QuizListRow`:** Updated the `onUpdate` callback in the `QuizListRow` to call `handleFetchQuizzes`, ensuring proper refresh after updates.

### Introduction of RecordingListRow Component:
- **New Component Creation:** A new component called `RecordingListRow` was created to encapsulate the recording listing logic.
- **Record Info Display:** The component displays recording information including title and upload date, with proper handling for empty titles.
- **Expanded State:** Integrated state management for the accordion expansion within each recording row.
- **AccordionQuizzes Rendering:** Conditionally renders the `AccordionQuizzes` component only when the respective recording row is expanded.

### General Code Improvements:
- **Reduced Imports:** Unused imports were removed to enhance code clarity.
- **Better Component Structure:** The separation of concerns has been improved by breaking down larger components into smaller, reusable ones.