### PR TITLE
Remove eslint-plugin-storybook and unused dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,6 @@
         "@storybook/test": "^8.5.1",
         "eslint": "^8.57.1",
         "eslint-plugin-react": "^7.37.2",
-        "eslint-plugin-storybook": "^0.11.2",
         "msw": "^2.7.0",
         "prettier": "^3.3.3",
         "storybook": "^8.5.1",
@@ -5425,7 +5424,6 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.12.tgz",
       "integrity": "sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==",
-      "dev": true,
       "dependencies": {
         "type-fest": "^2.19.0"
       }
@@ -5450,7 +5448,6 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "dev": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -10992,7 +10989,6 @@
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.11.2.tgz",
       "integrity": "sha512-0Z4DUklJrC+GHjCRXa7PYfPzWC15DaVnwaOYenpgXiCEijXPZkLKCms+rHhtoRcWccP7Z8DpOOaP1gc3P9oOwg==",
-      "dev": true,
       "dependencies": {
         "@storybook/csf": "^0.1.11",
         "@typescript-eslint/utils": "^8.8.1",
@@ -11009,7 +11005,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.21.0.tgz",
       "integrity": "sha512-G3IBKz0/0IPfdeGRMbp+4rbjfSSdnGkXsM/pFZA8zM9t9klXDnB/YnKOBQ0GoPmoROa4bCq2NeHgJa5ydsQ4mA==",
-      "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "8.21.0",
         "@typescript-eslint/visitor-keys": "8.21.0"
@@ -11026,7 +11021,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.21.0.tgz",
       "integrity": "sha512-PAL6LUuQwotLW2a8VsySDBwYMm129vFm4tMVlylzdoTybTHaAi0oBp7Ac6LhSrHHOdLM3efH+nAR6hAWoMF89A==",
-      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -11039,7 +11033,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.21.0.tgz",
       "integrity": "sha512-x+aeKh/AjAArSauz0GiQZsjT8ciadNMHdkUSwBB9Z6PrKc/4knM4g3UfHml6oDJmKC88a6//cdxnO/+P2LkMcg==",
-      "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "8.21.0",
         "@typescript-eslint/visitor-keys": "8.21.0",
@@ -11065,7 +11058,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.21.0.tgz",
       "integrity": "sha512-xcXBfcq0Kaxgj7dwejMbFyq7IOHgpNMtVuDveK7w3ZGwG9owKzhALVwKpTF2yrZmEwl9SWdetf3fxNzJQaVuxw==",
-      "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@typescript-eslint/scope-manager": "8.21.0",
@@ -11088,7 +11080,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.21.0.tgz",
       "integrity": "sha512-BkLMNpdV6prozk8LlyK/SOoWLmUFi+ZD+pcqti9ILCbVvHGk1ui1g4jJOc2WDLaeExz2qWwojxlPce5PljcT3w==",
-      "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "8.21.0",
         "eslint-visitor-keys": "^4.2.0"
@@ -11105,7 +11096,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -11114,7 +11104,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
       "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
-      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -11126,7 +11115,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -11141,7 +11129,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.0.tgz",
       "integrity": "sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==",
-      "dev": true,
       "engines": {
         "node": ">=18.12"
       },
@@ -23056,7 +23043,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
       "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
-      "dev": true,
       "engines": {
         "node": ">=6.10"
       }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "@storybook/test": "^8.5.1",
     "eslint": "^8.57.1",
     "eslint-plugin-react": "^7.37.2",
-    "eslint-plugin-storybook": "^0.11.2",
     "msw": "^2.7.0",
     "prettier": "^3.3.3",
     "storybook": "^8.5.1",


### PR DESCRIPTION
This commit removes the `eslint-plugin-storybook` package from both `package.json` and `package-lock.json`, as it is no longer needed. Additionally, unused `dev` flags in `package-lock.json` for various dependencies were cleaned up to streamline the lock file.