### PR TITLE
Enhance Quiz Actions Menu Interaction

### DIFF
--- a/src/blocks/QuizListRowMenu.jsx
+++ b/src/blocks/QuizListRowMenu.jsx
@@ -9,6 +9,7 @@ import { startQuizSession } from '../services/apiService';
 
 const QuizListRowMenu = ({ quiz, numQuestions, deleteQuiz, onUpdate }) => {
   const [editTitleOpen, setEditTitleOpen] = useState(false);
+  const [actionsMenuOpen, setActionsMenuOpen] = useState(false);
   const navigate = useNavigate();
 
   const startQuiz = async (quizId) =>
@@ -26,17 +27,41 @@ const QuizListRowMenu = ({ quiz, numQuestions, deleteQuiz, onUpdate }) => {
   };
   return (
     <>
-      <GenericMenu title="Actions">
-        <MenuItem onClick={() => startQuiz(quiz.id)} disableRipple>
+      <GenericMenu title="Actions" isOpen={actionsMenuOpen} setIsOpen={setActionsMenuOpen}>
+        <MenuItem
+          onClick={() => {
+            startQuiz(quiz.id);
+            setActionsMenuOpen(false);
+          }}
+          disableRipple
+        >
           <PlayArrow /> Start Quiz
         </MenuItem>
-        <MenuItem onClick={() => setEditTitleOpen(true)} disableRipple>
+        <MenuItem
+          onClick={() => {
+            setEditTitleOpen(true);
+            setActionsMenuOpen(false);
+          }}
+          disableRipple
+        >
           <Edit /> Edit Title
         </MenuItem>
-        <MenuItem onClick={() => viewQuestions(quiz.id)}>
+        <MenuItem
+          onClick={() => {
+            viewQuestions(quiz.id);
+            setActionsMenuOpen(false);
+          }}
+          disableRipple
+        >
           <List /> View Questions ({numQuestions})
         </MenuItem>
-        <MenuItem onClick={() => deleteQuiz(quiz.id)} disableRipple>
+        <MenuItem
+          onClick={() => {
+            deleteQuiz(quiz.id);
+            setActionsMenuOpen(false);
+          }}
+          disableRipple
+        >
           <Delete /> Delete Quiz
         </MenuItem>
       </GenericMenu>


### PR DESCRIPTION
KAN-310
This pull request includes changes to `src/blocks/QuizListRowMenu.jsx` to improve the user experience by ensuring the actions menu closes after an action is selected. The most important changes include adding state management for the actions menu and modifying `MenuItem` components to close the menu upon selection.

State management improvements:

* Added a new state variable `actionsMenuOpen` to manage the open/close state of the actions menu.

User experience improvements:

* Modified the `GenericMenu` component to accept `isOpen` and `setIsOpen` props for controlling the menu's state.
* Updated `MenuItem` components to close the actions menu after performing their respective actions (`startQuiz`, `setEditTitleOpen`, `viewQuestions`, `deleteQuiz`).ents to the interactions within the Quiz Actions Menu. The following changes have been implemented: