### PR TITLE
KAN-307: Add Recording Duration Component and Update Recording List

### DIFF
--- a/src/pages/InstructorRecordings/Components/RecordingDuration.tsx
+++ b/src/pages/InstructorRecordings/Components/RecordingDuration.tsx
@@ -1,0 +1,20 @@
+import { Typography } from '@mui/material';
+
+const RecordingDuration = ({ duration }: { duration: number }) => {
+  const formatDuration = (duration: number) => {
+    if (duration === 0) return '--';
+    const hours = Math.floor(duration / 3600);
+    const minutes = Math.floor((duration % 3600) / 60);
+    const seconds = duration % 60;
+
+    return [hours > 0 && `${hours}h`, minutes > 0 && `${minutes}m`, `${seconds}s`].filter(Boolean).join(' ');
+  };
+
+  return (
+    <Typography variant="body2" color="textSecondary">
+      {formatDuration(duration)}
+    </Typography>
+  );
+};
+
+export default RecordingDuration;

--- a/src/pages/InstructorRecordings/Components/RecordingListRow.tsx
+++ b/src/pages/InstructorRecordings/Components/RecordingListRow.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import RecordingListRowMenu from '../../../blocks/RecordingListRowMenu';
 import { Recording } from '../../../types/edukonaTypes';
 import AccordionQuizzes from './AccordionQuizzes';
+import RecordingDuration from './RecordingDuration';
 
 const RecordingListRow = ({ recording, onUpdate }: { recording: Recording; onUpdate: () => void }) => {
   const [expanded, setExpanded] = useState(false);
@@ -10,7 +11,7 @@ const RecordingListRow = ({ recording, onUpdate }: { recording: Recording; onUpd
     <React.Fragment key={recording.id}>
       {/* --- Row 1: Recording Info --- */}
       <TableRow sx={{ cursor: 'default' }}>
-        <TableCell align="center" sx={{ width: '25%' }}>
+        <TableCell align="center" sx={{ width: '30%' }}>
           <Box textAlign="center">
             <Button
               color="primary"
@@ -23,7 +24,7 @@ const RecordingListRow = ({ recording, onUpdate }: { recording: Recording; onUpd
             </Button>
           </Box>
         </TableCell>
-        <TableCell align="center" sx={{ width: '25%' }}>
+        <TableCell align="center" sx={{ width: '20%' }}>
           {new Date(recording.uploaded_at).toLocaleDateString(undefined, {
             year: 'numeric',
             month: 'long',
@@ -32,7 +33,10 @@ const RecordingListRow = ({ recording, onUpdate }: { recording: Recording; onUpd
             minute: 'numeric',
           })}
         </TableCell>
-        <TableCell align="center" sx={{ width: '25%' }}>
+        <TableCell align="center" sx={{ width: '15%' }}>
+          <RecordingDuration duration={recording.duration} />
+        </TableCell>
+        <TableCell align="center" sx={{ width: '15%' }}>
           <Box
             component="span"
             sx={{
@@ -46,7 +50,7 @@ const RecordingListRow = ({ recording, onUpdate }: { recording: Recording; onUpd
           />
           {recording.transcript.charAt(0).toUpperCase() + recording.transcript.slice(1)}
         </TableCell>
-        <TableCell align="center" sx={{ width: '25%' }}>
+        <TableCell align="center" sx={{ width: '10%' }}>
           <Box textAlign="center">
             <RecordingListRowMenu recording={recording} onUpdate={onUpdate} />
           </Box>

--- a/src/pages/InstructorRecordings/InstructorRecordings.jsx
+++ b/src/pages/InstructorRecordings/InstructorRecordings.jsx
@@ -80,22 +80,27 @@ const InstructorRecordings = () => {
           <Table>
             <TableHead>
               <TableRow>
-                <TableCell sx={{ width: '25%' }}>
+                <TableCell sx={{ width: '30%' }}>
                   <Typography variant="h6" align="center">
                     Title
                   </Typography>
                 </TableCell>
-                <TableCell sx={{ width: '25%' }}>
+                <TableCell sx={{ width: '20%' }}>
                   <Typography variant="h6" align="center">
                     Uploaded At
                   </Typography>
                 </TableCell>
-                <TableCell sx={{ width: '25%' }}>
+                <TableCell sx={{ width: '15%' }}>
+                  <Typography variant="h6" align="center">
+                    Duration
+                  </Typography>
+                </TableCell>
+                <TableCell sx={{ width: '15%' }}>
                   <Typography variant="h6" align="center">
                     Transcript Status
                   </Typography>
                 </TableCell>
-                <TableCell sx={{ width: '25%' }}>
+                <TableCell sx={{ width: '10%' }}>
                   <Typography variant="h6" align="center">
                     Actions
                   </Typography>

--- a/src/types/edukonaTypes.ts
+++ b/src/types/edukonaTypes.ts
@@ -5,6 +5,7 @@ export interface Recording {
   uploaded_at: string;
   instructor: string;
   transcript: string;
+  duration: number;
 }
 
 export interface Course {


### PR DESCRIPTION
KAN-307
This pull request introduces a new component for displaying the duration of recordings. The following changes were made to enhance the Instructor Recordings page:

### New Feature
- **Added `RecordingDuration` Component**:  
  - Created a new file `RecordingDuration.tsx` that formats and displays the duration of recordings in a readable format (e.g., `1h 30m 15s`).
  - Handles the case when the duration is `0` by displaying `--`.
  - Uses Material-UI's `Typography` for consistent styling.

### Updates to Existing Components
- **Updated `RecordingListRow` Component**:  
  - Imported the newly created `RecordingDuration` component.
  - Added `RecordingDuration` to the table, replacing the previously allocated space with appropriate width adjustments for all columns.
  - Adjusted the layout of the `TableCell`s to appropriately allocate space for the new `Duration` column.

### Updates to Instructor Recording Table
- **Modified `InstructorRecordings` Layout**:  
  - Added a header for the `Duration` column in the recordings table with a width of `15%`.
  - Adjusted the widths of the other columns accordingly to maintain a clean layout.

### Type Adjustments
- **Updated Recording Type**:  
  - Added `duration: number` to the `Recording` interface in `edukonaTypes.ts` to accommodate the new data being used to display the duration.

These changes improve the ability to monitor recording lengths directly within the interface, providing additional valuable information to instructors.