### PR TITLE
# Enhance Recording List with Transcript Download Functionality

### DIFF
--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -221,3 +221,5 @@ export const fetchInstructorCourses = () => api.get(`instructor/get-courses/`);
 export const fetchRecordingsByCourse = (course_id) => api.get(`course/${course_id}/get-recordings/`);
 
 export const createCourse = (courseData) => api.post(`instructor/create-course/`, courseData);
+
+export const getTranscript = (recordingId) => api.get(`recordings/${recordingId}/get-transcript`);

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -222,4 +222,4 @@ export const fetchRecordingsByCourse = (course_id) => api.get(`course/${course_i
 
 export const createCourse = (courseData) => api.post(`instructor/create-course/`, courseData);
 
-export const getTranscript = (recordingId) => api.get(`recordings/${recordingId}/get-transcript`);
+export const getTranscript = (recordingId) => api.get(`recordings/${recordingId}/get-transcript/`);


### PR DESCRIPTION
KAN-293
This pull request introduces functionality for downloading the transcript of a recording in the `RecordingListRowMenu` component. The following enhancements and changes have been made:

- **Added Transcript Download Capability:**
  - Introduced a new function `handleGetTranscript` that fetches the transcript for a given recording using the new API endpoint.
  - The fetched transcript is converted into a downloadable text file format.
  - A dynamic filename is generated for the transcript based on the recording title.
  - Utilizes a temporary anchor (`<a>`) element to trigger the download programmatically.
  - Proper error handling and user notifications are added using the `toast` library to notify users in case of failure.

- **Updated Imports and Menu Structure:**
  - Added `Download` icon from `@mui/icons-material` to the import statement for visual representation in the menu.
  - Added a new `MenuItem` labeled 'Download Transcript' to the `GenericMenu`, allowing users to download the transcript directly.
  - Ensured the menu closes after the download is initiated for better user experience.

- **API Service Enhancement:**
  - Implemented `getTranscript` method in the `apiService.js` module to interface with the new API for fetching transcripts based on recording ID.

### Summary of Changes:
- **Frontend Changes:**
  - Updated `RecordingListRowMenu.tsx`
    - Added transcript download functionality
    - Modified menu to include download option
  
- **Backend Integration:**
  - Updated `apiService.js`
    - Implemented `getTranscript` API call

This enhancement significantly improves the usability of the recording management feature, providing instructors and users a streamlined way to obtain transcripts.