### PR TITLE
[KAN-306] Add Change Course Functionality to Recording List

### DIFF
--- a/src/blocks/RecordingListRowMenu.tsx
+++ b/src/blocks/RecordingListRowMenu.tsx
@@ -1,7 +1,8 @@
-import { Delete, Download, Edit, Quiz, Summarize } from '@mui/icons-material';
+import { Delete, Download, Edit, Quiz, Summarize, SwapHoriz } from '@mui/icons-material';
 import { Divider, MenuItem } from '@mui/material';
 import { Fragment, useState } from 'react';
 import { toast } from 'react-toastify';
+import ChangeRecordingCourseDialog from '../pages/InstructorRecordings/Components/ChangeRecordingCourseDialog';
 import EditRecordingTitleDialog from '../pages/InstructorRecordings/Components/EditRecordingTitleDialog';
 import { getTranscript } from '../services/apiService';
 import { generateSummary } from '../services/lambdaService';
@@ -20,6 +21,7 @@ const RecordingListRowMenu = (props: RecordingListRowMenuProps) => {
   const [createQuizOpen, setCreateQuizOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [openMenu, setOpenMenu] = useState(false);
+  const [changeCourseOpen, setChangeCourseOpen] = useState(false);
 
   const handleGenerateSummary = () => {
     toast
@@ -103,6 +105,15 @@ const RecordingListRowMenu = (props: RecordingListRowMenuProps) => {
         </MenuItem>
         <MenuItem
           onClick={() => {
+            setChangeCourseOpen(true);
+            setOpenMenu(false);
+          }}
+          disableRipple
+        >
+          <SwapHoriz /> Change Course
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
             setDeleteOpen(true);
             setOpenMenu(false);
           }}
@@ -124,6 +135,13 @@ const RecordingListRowMenu = (props: RecordingListRowMenuProps) => {
         recordingId={props.recording.id}
         onUpdate={props.onUpdate}
         currentTitle={props.recording.title}
+      />
+      <ChangeRecordingCourseDialog
+        open={changeCourseOpen}
+        setOpen={setChangeCourseOpen}
+        recording_id={props.recording.id}
+        course_id={props.recording.course_id}
+        onUpdate={props.onUpdate}
       />
     </Fragment>
   );

--- a/src/pages/InstructorRecordings/Components/ChangeRecordingCourseDialog.tsx
+++ b/src/pages/InstructorRecordings/Components/ChangeRecordingCourseDialog.tsx
@@ -1,0 +1,132 @@
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Button,
+  Select,
+  MenuItem,
+  IconButton,
+  FormControl,
+  InputLabel,
+  FormHelperText,
+  Typography,
+  Box,
+  CircularProgress,
+} from '@mui/material';
+import { useState, useEffect, useContext } from 'react';
+import { toast } from 'react-toastify';
+import CloseIcon from '@mui/icons-material/Close';
+import { InstructorContext } from '../../../InstructorContext';
+import { moveRecordingToCourse } from '../../../services/apiService';
+
+interface ChangeRecordingCourseDialogProps {
+  open: boolean;
+  setOpen(open: boolean): void;
+  recording_id: string;
+  course_id: string;
+  onUpdate(): void;
+}
+
+const ChangeRecordingCourseDialog: React.FC<ChangeRecordingCourseDialogProps> = ({
+  open,
+  setOpen,
+  recording_id,
+  course_id,
+  onUpdate,
+}) => {
+  const { courses } = useContext(InstructorContext);
+  const course_titles: { id: string; title: string }[] = courses
+    ? courses.filter((course) => course.id !== course_id).map((course) => ({ id: course.id, title: course.title }))
+    : [];
+  const [selectedCourseId, setSelectedCourseId] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const hasAvailableCourses = course_titles.length > 0;
+
+  // Reset selected course when dialog opens
+  useEffect(() => {
+    if (open) {
+      setSelectedCourseId(course_titles[0]?.id || '');
+    }
+  }, [open, course_titles]);
+
+  const handleCancel = () => {
+    setOpen(false);
+  };
+
+  const handleConfirm = () => {
+    if (!selectedCourseId) return;
+
+    setIsLoading(true);
+    moveRecordingToCourse(recording_id, selectedCourseId)
+      .then(() => {
+        toast.success('Course changed successfully');
+        onUpdate(); // Only update after successful API call
+        setOpen(false);
+      })
+      .catch((err) => {
+        console.error('Error changing course:', err);
+        toast.error('Failed to change course');
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  };
+
+  return (
+    <Dialog open={open} fullWidth aria-labelledby="change-recording-course-dialog-title" onClose={handleCancel}>
+      <DialogTitle id="change-recording-course-dialog-title">
+        Change Recording Course
+        <IconButton
+          aria-label="close"
+          onClick={handleCancel}
+          sx={{
+            position: 'absolute',
+            right: 8,
+            top: 8,
+          }}
+        >
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        {!hasAvailableCourses ? (
+          <Typography color="error">No other courses available to move this recording to.</Typography>
+        ) : (
+          <FormControl fullWidth margin="normal">
+            <InputLabel id="select-course-label">Target Course</InputLabel>
+            <Select
+              labelId="select-course-label"
+              value={selectedCourseId}
+              onChange={(e) => setSelectedCourseId(e.target.value as string)}
+              label="Target Course"
+              disabled={isLoading}
+            >
+              {course_titles.map((course) => (
+                <MenuItem key={course.id} value={course.id}>
+                  {course.title}
+                </MenuItem>
+              ))}
+            </Select>
+            <FormHelperText>Select the course you want to move this recording to</FormHelperText>
+          </FormControl>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleCancel} color="primary" disabled={isLoading}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleConfirm}
+          color="primary"
+          disabled={!selectedCourseId || isLoading || !hasAvailableCourses}
+          variant="contained"
+        >
+          {isLoading ? <CircularProgress size={24} /> : 'Confirm'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ChangeRecordingCourseDialog;

--- a/src/pages/InstructorRecordings/Components/ChangeRecordingCourseDialog.tsx
+++ b/src/pages/InstructorRecordings/Components/ChangeRecordingCourseDialog.tsx
@@ -11,10 +11,9 @@ import {
   InputLabel,
   FormHelperText,
   Typography,
-  Box,
   CircularProgress,
 } from '@mui/material';
-import { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect, useContext, useMemo } from 'react';
 import { toast } from 'react-toastify';
 import CloseIcon from '@mui/icons-material/Close';
 import { InstructorContext } from '../../../InstructorContext';
@@ -36,9 +35,11 @@ const ChangeRecordingCourseDialog: React.FC<ChangeRecordingCourseDialogProps> = 
   onUpdate,
 }) => {
   const { courses } = useContext(InstructorContext);
-  const course_titles: { id: string; title: string }[] = courses
-    ? courses.filter((course) => course.id !== course_id).map((course) => ({ id: course.id, title: course.title }))
-    : [];
+  const course_titles = useMemo(() => {
+    return courses
+      ? courses.filter((course) => course.id !== course_id).map((course) => ({ id: course.id, title: course.title }))
+      : [];
+  }, [courses, course_id]);
   const [selectedCourseId, setSelectedCourseId] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const hasAvailableCourses = course_titles.length > 0;

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -251,3 +251,6 @@ export const fetchRecordingsByCourse = (course_id) => api.get(`course/${course_i
 export const createCourse = (courseData) => api.post(`instructor/create-course/`, courseData);
 
 export const getTranscript = (recordingId) => api.get(`recordings/${recordingId}/get-transcript/`);
+
+export const moveRecordingToCourse = (recording_id, course_id) =>
+  api.patch(`recordings/${recording_id}/move-recording-to-course/`, { course_id: course_id });

--- a/src/types/edukonaTypes.ts
+++ b/src/types/edukonaTypes.ts
@@ -6,6 +6,7 @@ export interface Recording {
   instructor: string;
   transcript: string;
   duration: number;
+  course_id: string;
 }
 
 export interface Course {


### PR DESCRIPTION
This pull request introduces the ability to change the course associated with a recording within the Recording List component. The notable changes include the addition of new UI elements and backend functionality to support this feature.

### Changes Made:
- **Modification of `RecordingListRowMenu.tsx`:**  
  - Imported the `SwapHoriz` icon from `@mui/icons-material`.  
  - Added state management for the new change course dialog.  
  - Introduced a new menu item for changing the course of a recording.  
  - Added the `ChangeRecordingCourseDialog` component to manage the course-switching UI.

- **Creation of `ChangeRecordingCourseDialog.tsx`:**  
  - Implemented a dialog component to allow selecting a new course for the recording.  
  - Integrated user feedback through toast notifications on success or failure of the API call.
  - Used context to retrieve available courses for the user.
  - Handled API requests to move recordings to a different course using `moveRecordingToCourse`.

- **Update to `apiService.js`:**  
  - Added a new API function `moveRecordingToCourse` that handles the logic for updating the recording's course in the backend.

- **Update to `edukonaTypes.ts`:**  
  - Added `course_id` to the `Recording` interface to properly track the course association.

### Screenshots:
- (Include any relevant screenshots that show the new dialog and menu item.)

### Testing:
- Confirmed that the dialog opens correctly and displays available courses.  
- Verified that changing the course updates the recording as expected in the API.  
- Successfully handled scenarios where no other courses are available for selection.