### PR TITLE
[KAN-320] Enhance Editable Question Component Layout

### DIFF
--- a/src/blocks/EditableQuestion.jsx
+++ b/src/blocks/EditableQuestion.jsx
@@ -1,5 +1,5 @@
 import { Delete, EditNote, Save, Undo } from '@mui/icons-material';
-import { Box, Button, FormControl, Grid, Paper, TextField } from '@mui/material';
+import { Box, Button, FormControl, Grid, Paper, TextField, Divider } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
 import DeleteQuestionDialog from './DeleteQuestionDialog';
@@ -44,7 +44,7 @@ const EditableQuestion = ({ question, token, onUpdate }) => {
       <Paper style={{ padding: '20px', margin: '15px' }} component={'form'} onSubmit={(e) => handleSave(e)}>
         <Grid container spacing={2}>
           <Grid item xs={10}>
-            <FormControl>
+            <FormControl fullWidth>
               <TextField
                 id={'question_text'}
                 name={'question_text'}
@@ -73,7 +73,7 @@ const EditableQuestion = ({ question, token, onUpdate }) => {
             </FormControl>
           </Grid>
           <Grid item xs={12}>
-            <FormControl>
+            <FormControl fullWidth>
               <TextField
                 id={'correct_answer'}
                 name={'correct_answer'}
@@ -88,10 +88,12 @@ const EditableQuestion = ({ question, token, onUpdate }) => {
           </Grid>
           {questionData.incorrect_answer_list.map((incorrectAnswer, idx) => (
             <Grid item container key={idx} xs={12} spacing={2}>
-              <Grid item xs={6}>
-                <FormControl>
+              <Grid item xs={12}>
+                <Divider />
+              </Grid>
+              <Grid item xs={12} md={6}>
+                <FormControl fullWidth>
                   <TextField
-                    key={`answer-${idx}`}
                     id={`answer-${idx}`}
                     label={'Answer'}
                     name={`answer-${idx}`}
@@ -103,10 +105,9 @@ const EditableQuestion = ({ question, token, onUpdate }) => {
                   />
                 </FormControl>
               </Grid>
-              <Grid item xs={6}>
-                <FormControl>
+              <Grid item xs={12} md={6}>
+                <FormControl fullWidth>
                   <TextField
-                    key={`feedback-${idx}`}
                     id={`feedback-${idx}`}
                     label={'Feedback'}
                     name={`feedback-${idx}`}


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/1d6c896a-516c-45c4-bf4f-76f81fba696a)

This PR refines the layout of the Editable Question component by making several key adjustments to form controls and overall structure. The changes improve usability and accessibility. Below is a summary of the modifications made:

- **Imports**:
  - Added `Divider` to the imports from `@mui/material` for better visual separation of answers.

- **FormControl Adjustments**:
  - Changed the `FormControl` element for the question text field to have `fullWidth` to utilize the available space better.
  - Updated the `FormControl` for the correct answer field to also have `fullWidth` to maintain a consistent layout.

- **Layout Improvements for Incorrect Answers**:
  - Reorganized the layout for the incorrect answers section:
    - Added a `Divider` between the different answer fields to improve readability and distinguish between answers.
    - Adjusted the grid item structure for answer fields to span the entire width on smaller screens (`xs={12}`) and half-width on medium and larger screens (`md={6}`). This allows for a more responsive design while ensuring all components fit well without crowding.
  - Updated the corresponding `FormControl` elements for each incorrect answer to include `fullWidth` to maximize space efficiency.

- **Feedback Fields**:
  - Adjusted the layout of the feedback fields for each incorrect answer to mirror the changes made in the answer fields, allowing for consistent groupings and enhancing user experience. 

Overall, these changes enhance the structure and usability of the Editable Question component, improving the interface for users.