### PR TITLE
[KAN-331] Refactor JWTUserContext Component for Improved Token Management

### DIFF
--- a/src/JWTUserContext.tsx
+++ b/src/JWTUserContext.tsx
@@ -78,7 +78,7 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
   const [accessToken, setAccessToken] = useState<string | null>(localStorage.getItem('accessToken'));
   const [refreshToken, setRefreshToken] = useState<string | null>(localStorage.getItem('refreshToken'));
 
-  const [isLoggedIn, setIsLoggedIn] = useState(!(accessToken === null));
+  const [isLoggedIn, setIsLoggedIn] = useState(!!accessToken);
   const [user, setUser] = useState<number | null>(getUserLocalStorage());
 
   const reset = () => {
@@ -92,19 +92,20 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
   };
 
   useEffect(() => {
-    if (accessToken === null) {
-      reset();
-    } else {
+    if (accessToken) {
+      localStorage.setItem('accessToken', accessToken);
       setIsLoggedIn(true);
+    } else {
+      reset();
     }
   }, [accessToken]);
 
   useEffect(() => {
-    localStorage.setItem('accessToken', accessToken || '');
-  }, [accessToken]);
-
-  useEffect(() => {
-    localStorage.setItem('refreshToken', refreshToken || '');
+    if (refreshToken) {
+      localStorage.setItem('refreshToken', refreshToken);
+    } else {
+      localStorage.removeItem('refreshToken');
+    }
   }, [refreshToken]);
 
   const login = async (username: string, password: string, setError: SetErrorFunction, navigate: NavigateFunction) => {


### PR DESCRIPTION
This pull request contains several key improvements to the `JWTUserContext` component related to token handling and user login state management:

- **Updated isLoggedIn State Initialization**: 
  - Changed the initialization of the `isLoggedIn` state to `!!accessToken`, directly reflecting the presence of an access token rather than using a comparison to `null`.

- **Refined useEffect for Access Token**: 
  - Simplified the logic within the `useEffect` hook that listens to changes in the `accessToken` state.
  - Removed unnecessary checks against `null` and encapsulated the setting of the `isLoggedIn` state and local storage updates.
  - Added an `else` condition to call the `reset` function when `accessToken` is absent.

- **Streamlined Token Storage for Refresh Token**: 
  - Updated the logic in the `useEffect` that handles the `refreshToken` to avoid setting an empty string in local storage when the token is not present.
  - Instead of setting an empty value, it now removes the `refreshToken` from local storage if it is `null` or not provided, ensuring cleaner token management.

These changes contribute to a more efficient, cleaner, and maintainable codebase by optimizing token handling and providing clearer state management practices.